### PR TITLE
Detect Ubuntu packages already installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
 language: ruby
 sudo: required
 
+addons:
+  apt:
+    packages:
+      - rpm
+      - libaio-dev
+
 env:
   global:
     - ORACLE_COOKIE=sqldev
     - ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
     - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
     - ORACLE_SID=XE
+
+matrix:
+  include:
+    - env: APT_ADDON=1
+
+    - env: APT_ADDON=0
+      addons:
+        apt: false
 
 before_install:
   - ./download.sh

--- a/install.sh
+++ b/install.sh
@@ -4,11 +4,13 @@
 [ -n "$ORACLE_HOME" ] || { echo "Missing ORACLE_HOME environment variable!"; exit 1; }
 
 ORACLE_RPM="$(basename $ORACLE_FILE .zip)"
+# Note that Travis ubuntu and trusty images contain bc and unzip
+PACKAGE_DEPENDENCIES="libaio1 rpm"
 
 cd "$(dirname "$(readlink -f "$0")")"
 
 sudo apt-get -qq update
-sudo apt-get --no-install-recommends -qq install bc libaio1 rpm unzip
+sudo apt-get --no-install-recommends -qq install $PACKAGE_DEPENDENCIES
 
 df -B1 /dev/shm | awk 'END { if ($1 != "shmfs" && $1 != "tmpfs" || $2 < 2147483648) exit 1 }' ||
   ( sudo rm -r /dev/shm && sudo mkdir /dev/shm && sudo mount -t tmpfs shmfs -o size=2G /dev/shm )

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,13 @@ PACKAGE_DEPENDENCIES="libaio1 rpm"
 
 cd "$(dirname "$(readlink -f "$0")")"
 
-sudo apt-get -qq update
-sudo apt-get --no-install-recommends -qq install $PACKAGE_DEPENDENCIES
+if dpkg -s $PACKAGE_DEPENDENCIES >/dev/null 2>/dev/null; then
+  echo "Oracle XE dependencies are already installed: $PACKAGE_DEPENDENCIES"
+else
+  echo "Installing Oracle XE dependencies: $PACKAGE_DEPENDENCIES"
+  sudo apt-get -qq update
+  sudo apt-get --no-install-recommends -qq install $PACKAGE_DEPENDENCIES
+fi
 
 df -B1 /dev/shm | awk 'END { if ($1 != "shmfs" && $1 != "tmpfs" || $2 < 2147483648) exit 1 }' ||
   ( sudo rm -r /dev/shm && sudo mkdir /dev/shm && sudo mount -t tmpfs shmfs -o size=2G /dev/shm )


### PR DESCRIPTION
Avoid installing them again when it is not required.

Set up an extra job that uses Travis addon 'apt'
to pre-install the required dependencies.
