### PR TITLE
Install real chkconfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       addons:
         apt:
           packages:
+            - chkconfig
             - libaio1
             - rpm
 

--- a/install.sh
+++ b/install.sh
@@ -7,14 +7,21 @@ ORACLE_RPM="$(basename $ORACLE_FILE .zip)"
 
 cd "$(dirname "$(readlink -f "$0")")"
 
-dpkg -s bc libaio1 rpm unzip > /dev/null 2>&1 ||
-  ( sudo apt-get -qq update && sudo apt-get --no-install-recommends -qq install bc libaio1 rpm unzip )
+DEPS="bc libaio1 rpm unzip"
+if [ "$_system_version" = "12.04" ]; then
+   DEPS="$DEPS chkconfig"
+fi
+dpkg -s $DEPS > /dev/null 2>&1 ||
+  ( sudo apt-get -qq update && sudo apt-get --no-install-recommends -qq install $DEPS )
+
+# chkconfig expects /sbin/insserv to exist
+sudo ln -s /usr/lib/insserv/insserv /sbin/insserv
 
 df -B1 /dev/shm | awk 'END { if ($1 != "shmfs" && $1 != "tmpfs" || $2 < 2147483648) exit 1 }' ||
   ( sudo rm -r /dev/shm && sudo mkdir /dev/shm && sudo mount -t tmpfs shmfs -o size=2G /dev/shm )
 
 test -f /sbin/chkconfig ||
-  ( echo '#!/bin/sh' | sudo tee /sbin/chkconfig > /dev/null && sudo chmod u+x /sbin/chkconfig )
+  ( echo '#!/bin/sh' | sudo tee /sbin/chkconfig > /dev/null && sudo chmod 755 /sbin/chkconfig )
 
 test -d /var/lock/subsys || sudo mkdir /var/lock/subsys
 

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -12,8 +12,8 @@ describe 'install.sh' do
     executable = '/sbin/chkconfig'
 
     expect(File).to exist(executable)
-    expect(File.lstat(executable).mode).to eq('100744'.to_i(8))
-    expect(IO.read(executable)).to eq("#!/bin/sh\n")
+    expect(File.lstat(executable).mode).to eq('100755'.to_i(8))
+    expect(IO.read(executable)).to start_with("#!/")
   end
 
   it 'creates a directory at /var/lock/subsys' do


### PR DESCRIPTION
chkconfig is a dependency of oracle-xe installer, so it would be good to use the actual package, and not create an empty shell script.
It was whitelisted as an apt package (https://github.com/travis-ci/apt-package-whitelist/issues/2465), and is used by https://github.com/scop/bash-completion
