### PR TITLE
Download zip file into ORACLE_ZIP_DIR if present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,12 @@ matrix:
             - rpm
 
 before_install:
-  - ./download.sh
+  # On trusty, download the zip file into a cachable directory
+  - test "$DIST" = precise || export ORACLE_ZIP_DIR=$HOME/.cache
+  # If the zip file already exists, do not download it again
+  - test -f "$ORACLE_ZIP_DIR"/$(basename $ORACLE_FILE) || ./download.sh
   - ./install.sh
+
+cache:
+  - directories:
+    - $HOME/.cache

--- a/download.js
+++ b/download.js
@@ -1,5 +1,8 @@
 // vim: set et sw=2 ts=2:
 "use strict";
+
+var fs = require('fs');
+
 var env = process.env;
 var Promise = require('bluebird');
 var Phantom = Promise.promisifyAll(require('node-phantom-simple'));
@@ -12,6 +15,14 @@ var credentials = Object.keys(env)
 if (credentials.length <= 0) {
   console.error("Missing ORACLE_LOGIN environment variables!");
   process.exit(1);
+}
+
+if (env['ORACLE_ZIP_DIR']) {
+  var directory = env['ORACLE_ZIP_DIR'];
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory);
+  }
+  process.chdir(directory);
 }
 
 Phantom.createAsync({ parameters: { 'ssl-protocol': 'tlsv1' } }).then(function (browser) {

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,14 @@ cd "$(dirname "$(readlink -f "$0")")"
 dpkg -s bc libaio1 rpm unzip > /dev/null 2>&1 ||
   ( sudo apt-get -qq update && sudo apt-get --no-install-recommends -qq install bc libaio1 rpm unzip )
 
+if [ "$ORACLE_ZIP_DIR" != "" ]; then
+  ORACLE_ZIP="$ORACLE_ZIP_DIR/$(basename $ORACLE_FILE)"
+else
+  ORACLE_ZIP="$(basename $ORACLE_FILE)"
+fi
+
+unzip -j $ORACLE_ZIP "*/$ORACLE_RPM"
+
 df -B1 /dev/shm | awk 'END { if ($1 != "shmfs" && $1 != "tmpfs" || $2 < 2147483648) exit 1 }' ||
   ( sudo rm -r /dev/shm && sudo mkdir /dev/shm && sudo mount -t tmpfs shmfs -o size=2G /dev/shm )
 
@@ -18,7 +26,6 @@ test -f /sbin/chkconfig ||
 
 test -d /var/lock/subsys || sudo mkdir /var/lock/subsys
 
-unzip -j "$(basename $ORACLE_FILE)" "*/$ORACLE_RPM"
 sudo rpm --install --nodeps --nopre "$ORACLE_RPM"
 
 echo 'OS_AUTHENT_PREFIX=""' | sudo tee -a "$ORACLE_HOME/config/scripts/init.ora" > /dev/null

--- a/spec/download_spec.rb
+++ b/spec/download_spec.rb
@@ -1,7 +1,15 @@
 
 describe 'download.sh' do
-  context 'when ORACLE_FILE is defined', :if => ENV.has_key?('ORACLE_FILE') do
-    it 'downloads from Oracle' do
+  context 'when ORACLE_FILE and ORACLE_ZIP_DIR are defined', :if => ENV.has_key?('ORACLE_FILE') && ENV.has_key?('ORACLE_ZIP_DIR') do
+    let(:zip) { ENV['ORACLE_ZIP_DIR'] + '/' + File.basename(ENV['ORACLE_FILE']) }
+
+    it 'downloads from Oracle into the specified directory' do
+      expect(File).to exist(zip)
+    end
+  end
+
+  context 'when only ORACLE_FILE is defined', :if => ENV.has_key?('ORACLE_FILE') && ! ENV.has_key?('ORACLE_ZIP_DIR') do
+    it 'downloads from Oracle into the current working directory' do
       expect(File).to exist(File.basename(ENV['ORACLE_FILE']))
     end
   end


### PR DESCRIPTION
If ORACLE_ZIP_DIR is set, the zip file is stored in that
directory.

This allows the zip file to be located outside of the source tree,
and thus in a cachable directory as required for the Travis caching
system, which became available on trusty images on 03-05-2016.
https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone

While the Oracle XE download time is negligible, the downloaded
Oracle XE zip is made available to pull requests, whereas currently
download.js fails because ORACLE_LOGIN_\* environment variables are
not available to pull requests.
https://docs.travis-ci.com/user/caching/
